### PR TITLE
Fix pronounce procedure

### DIFF
--- a/EnglishDictionary.rkt
+++ b/EnglishDictionary.rkt
@@ -106,14 +106,9 @@
 (define app_key "app_key:761ad80847bb97ee40842f7ecc43fade")
 (define open_api "https://od-api.oxforddictionaries.com:443/api/v1/entries/en/")
 
-
-
-(define myrespond "")
-
 (define file-path "C:\\Users\\sokthai\\Downloads/")
 (define sound-url "")
 (define result "")
-
 
 (define macPath "/Users/sokthaitang/downloads/") ; path for mac
 (define winPath "C:\\Users\\thai\\Downloads\\") ; path for widnow
@@ -121,14 +116,10 @@
 (define path ubuPath)
 
 (define (search w)
-
-  
-  ;(define result "")
   (set! result "")
   (define con-url (string->url (string-append open_api w)))
   (define dict-port (get-pure-port con-url (list app_id app_key)))
   (define respond (port->string dict-port))
-  ;(set! myrespond respond)
   (close-input-port dict-port)
   
   (cond ((number? (string-contains respond "404 Not Found")) (set! result (list (list "Error:" "Not Found"))))
@@ -148,16 +139,9 @@
   result
 )
 
-
-
-
 (define (readjson-from-input var)
   (with-input-from-string var
-    (lambda () (read-json)))
-      
-  )
-
-
+    (lambda () (read-json))))
 
 (define (searchDict hash k des)
   (cond ((list? hash)  (searchDict (car hash) k des))
@@ -167,9 +151,6 @@
                 (for (((key val) (in-hash hash)))
                   (searchDict (hash-ref hash key) k des)))                  
                (else hash)))))
-
-
-
 
 (define (display hash k des)
   (cond  
@@ -184,46 +165,22 @@
   )
 )
 
-
-
-
 (define (return des content )
   
   (if (list? result)
       (set! result (append result (list (list des content))))
       (set! result (list (list des content))))
-  
-  
 )
   
-
 (define (show lst k des)
-
   (cond ((null? lst) lst)
         (else
          (for (((key val) (in-hash (car lst )))) 
           (return des val)
            )
-
          (show (cdr lst) k des)
          ))
   )
-
-
-
-
-(module file-player racket/base
-   (require racket/system)
-   (define player (find-executable-path "xmms"))
-   (define (play file)
-     (system* player (if (path? file) (path->string file) file)))
-   (provide play))
-
-
-
-
-;-----play mp3
-
 
 (define (soundPath lst)
   
@@ -235,12 +192,8 @@
 
 (define (pronounce lst)
   (let ((audioURL (soundPath lst)))
-    (cond  ((equal? lst "") '())
+    (cond  ((equal? (caar lst) "Error:") '())
            (else
             (play-sound
-               (string-append path
-                                       (substring audioURL 43
-                                                  (string-length audioURL))) #t)))
- )
-  )
+               (string-append path (substring audioURL 43 (string-length audioURL))) #t)))))
 


### PR DESCRIPTION
Prevent pronounce procedure not to crash when no word is found (Error: 404: Not Found)